### PR TITLE
clash-chinese-patch (Fix): Hash check failed

### DIFF
--- a/bucket/clash-chinese-patch.json
+++ b/bucket/clash-chinese-patch.json
@@ -25,5 +25,5 @@
         ]
     },
     "url": "https://github.com/BoyceLig/Clash_Chinese_Patch/releases/download/0.18.10/app.Simplified.Chinese.version.7z",
-    "hash": "bcd8e025a216ce6aa80f5a107ce8dcfc73d922f5f7c72f0da302c656c3c61811"
+    "hash": "01dd533c6712f7abe887e3b31ad7d04d6fa17979836de7ef16e4f704aad71718"
 }


### PR DESCRIPTION
I can't figure out why GitHub Actions calculated a wrong hash value for me.

Close #2 .